### PR TITLE
Add bounties to project markdown files

### DIFF
--- a/src/projects/ClassiqLibrary.md
+++ b/src/projects/ClassiqLibrary.md
@@ -12,7 +12,14 @@ tags:
   - Quantum Applications
   - Python
 bounties:
-  - TBD
+  - issue_num: 28
+    value: 50
+  - issue_num: 34
+    value: 120
+  - issue_num: 36
+    value: 80
+  - issue_num: 41
+    value: 150
 ---
 # Classiq
 

--- a/src/projects/OpenQASM3Parser.md
+++ b/src/projects/OpenQASM3Parser.md
@@ -11,7 +11,16 @@ tags:
   - OpenQASM
   - parser
 bounties:
-  - TBD
+  - issue_num: 626
+    value: 150
+  - issue_num: 618
+    value: 75
+  - issue_num: 619
+    value: 125
+  - issue_num: 624
+    value: 75
+  - issue_num: 625
+    value: 75
 ---
 
 `openqasm3_parser` provides a compiler front end for OpenQASM 3 language (OQ3).

--- a/src/projects/Qadence.md
+++ b/src/projects/Qadence.md
@@ -9,7 +9,14 @@ tags:
   - Digital Analog
   - Differentiability
 bounties:
-  - TBD
+  - issue_num: 370
+    value: 100
+  - issue_num: 368
+    value: 100
+  - issue_num: 268
+    value: 50
+  - issue_num: 214
+    value: 100
 ---
 
 ## Feature highlights

--- a/src/projects/QuTip_Tutorials.md
+++ b/src/projects/QuTip_Tutorials.md
@@ -10,7 +10,16 @@ tags:
   - QuTip
   - Tutorials
 bounties:
-  - TBD
+  - issue_num: 918
+    value: 100
+  - issue_num: 880
+    value: 50
+  - issue_num: 851
+    value: 150
+  - issue_num: 119
+    value: 100
+  - issue_num: 878
+    value: 100
 ---
 
 This repository collects tutorials of different complexity for using [QuTiP](https://qutip.org/). Some of the notebooks are also shown on the [QuTiP Tutorials website](https://qutip.org/tutorials).

--- a/src/projects/Quantum_Machines_QUA-to-Qiskit_compiler_simulator.md
+++ b/src/projects/Quantum_Machines_QUA-to-Qiskit_compiler_simulator.md
@@ -15,7 +15,18 @@ tags:
   - Transmons
   - Quantum simulation
 bounties:
-  - TBD
+  - issue_num: 1
+    value: 50
+  - issue_num: 2
+    value: 75
+  - issue_num: 3
+    value: 75
+  - issue_num: 4
+    value: 100
+  - issue_num: 5
+    value: 100
+  - issue_num: 6
+    value: 100
 ---
 
 Unlock the full potential of quantum computing with our cutting-edge project that converts QUA, QM's hardware programming language, into a Qiskit Pulse representation. This advancement allows developers to directly simulate quantum-control programs on virtual qubit systems, bypassing the need for physical quantum hardware. This enhanced capability not only accelerates the development and testing of quantum applications but also deepens user understanding and intuition of QUA, Qiskit, and the broader field of quantum computing.

--- a/src/projects/Qublitz.md
+++ b/src/projects/Qublitz.md
@@ -11,6 +11,11 @@ tags:
   - Two-level qubit
   - Gates
 bounties:
-  - TBD
+  - issue_num: 10
+    value: 40
+  - issue_num: 9
+    value: 230
+  - issue_num: 8
+    value: 230
 ---
 [Qublitz](https://qublitz-qubit-lab.streamlit.app/) enables students and other users curious about quantum computing to develop an intuition for computational principles by challenging them to navigate along the Bloch sphere using gates. Using a simulation of a two-state qubit, users will be shown how specific gates work and then be challenged to navigate to destinations along the Bloch Sphere to beat the challenge! They will learn to make their own gates by defining parameters for electromagnetic pulses sent to the qubit and explore the engineering behind quantum computation. 

--- a/src/projects/bloqade-python.md
+++ b/src/projects/bloqade-python.md
@@ -13,7 +13,12 @@ tags:
   - Quantum Simulation
   - Pulse
 bounties:
-  - TBD
+  - issue_num: 957
+    value: 200
+  - issue_num: 876
+    value: 200
+  - issue_num: 741
+    value: 20
 ---
 
 Bloqade is an SDK designed to make writing and analyzing the results of analog quantum programs on QuEra's neutral atom quantum computers as seamless and flexible as possible. Currently, QuEra's hardware is on Amazon Braket, the primary method of accessing QuEra's quantum hardware. Over the alpha phase, we plan to expand the emulator capabilities to include a performance Python emulator but also a direct integration with Julia via [Bloqade.jl](https://queracomputing.github.io/Bloqade.jl/dev/).

--- a/src/projects/graphix.md
+++ b/src/projects/graphix.md
@@ -11,7 +11,16 @@ tags:
   - Measurement calculus
   - python
 bounties:
-  - TBD
+  - issue_num: 48
+    value: 130
+  - issue_num: 70
+    value: 100
+  - issue_num: 136
+    value: 100
+  - issue_num: 101
+    value: 40
+  - issue_num: 137
+    value: 40
 ---
 
 Graphix is a measurement-based quantum computing (MBQC) software package, featuring

--- a/src/projects/kqcircuits.md
+++ b/src/projects/kqcircuits.md
@@ -11,7 +11,18 @@ tags:
   - eda
   - lithography
 bounties:
-  - TBD
+  - issue_num: 45
+    value: 150
+  - issue_num: 52
+    value: 75
+  - issue_num: 91
+    value: 75
+  - issue_num: 89
+    value: 75
+  - issue_num: 90
+    value: 75
+  - issue_num: 90
+    value: 50
 ---
 
 KQCircuits generates multi-layer 2-dimensional-geometry representing common structures in quantum processing units (QPU). It includes definitions of parametrized geometrical objects or “elements”, framework to easily define your own elements, framework to get geometry from the elements by setting values to parameters and a framework to assemble a full QPU design by combining many of the elements in different geometrical relations. Among other templates, are also structures to combine QPU designs to create optical mask layout and EBL patterns for fabrication of quantum circuits and export a set of files for a mask as needed for QPU fabrication. KQCircuits also provides a way to export designed geometry to be simulated by third-party simulators like Ansys and Elmer.

--- a/src/projects/lambeq.md
+++ b/src/projects/lambeq.md
@@ -13,7 +13,14 @@ tags:
   - string diagrams
   - pcqs
 bounties:
-  - TBD
+  - issue_num: 140
+    value: 200
+  - issue_num: 142
+    value: 100
+  - issue_num: 141
+    value: 100
+  - issue_num: 143
+    value: 100
 ---
 
 lambeq is an open-source, modular, extensible high-level Python library for experimental Quantum Natural Language Processing (QNLP), created by Quantinuum's QNLP team. At a high level, the library allows the conversion of any sentence to a quantum circuit, based on a given compositional model and certain parameterisation and choices of ansätze, and facilitates training for both quantum and classical NLP experiments.

--- a/src/projects/metriq.md
+++ b/src/projects/metriq.md
@@ -12,7 +12,16 @@ tags:
   - react
   - benchmarking
 bounties:
-  - TBD
+  - issue_num: 918
+    value: 100
+  - issue_num: 880
+    value: 50
+  - issue_num: 851
+    value: 150
+  - issue_num: 119
+    value: 100
+  - issue_num: 878
+    value: 100
 ---
 There has been rapid progress in quantum computing, but it can be hard to track that progress. Researchers want to know how to compare against the state of the art and users want to know what tools best suit them.
 

--- a/src/projects/mitiq.md
+++ b/src/projects/mitiq.md
@@ -11,16 +11,16 @@ tags:
   - run-on-hardware
   - python
 bounties:
-  - issue_num: 1377
-    value: 100
-  - issue_num: 1244
-    value: 50
-  - issue_num: 1835
+  - issue_num: 1794
+    value: 140
+  - issue_num: 2354
     value: 80
-  - issue_num: 1619
-    value: 120
-  - issue_num: 1715
+  - issue_num: 2161
+    value: 70
+  - issue_num: 2346
     value: 100
+  - issue_num: 1813
+    value: 110
 ---
 
 Mitiq is a Python toolkit for implementing error mitigation techniques on quantum computers.

--- a/src/projects/qBraid-QIR.md
+++ b/src/projects/qBraid-QIR.md
@@ -12,7 +12,16 @@ tags:
   - Cirq
   - OpenQASM
 bounties:
-  - TBD
+  - issue_num: 626
+    value: 150
+  - issue_num: 618
+    value: 75
+  - issue_num: 619
+    value: 125
+  - issue_num: 624
+    value: 75
+  - issue_num: 625
+    value: 75
 ---
 
 Python package for generating [QIR](https://www.qir-alliance.org/) (Quantum Intermediate Representation) programs from high-level quantum programming languages. Currently supports conversions for Cirq and OpenQASM 3. This project aims to make QIR representations accessible via the [qBraid-SDK transpiler](https://github.com/qBraid/qBraid), and by doing so, open the door to language-specific conversions from any and all high-level quantum languages [supported](https://docs.qbraid.com/en/latest/sdk/overview.html#supported-frontends) by `qbraid`. See QIR Alliance: [why do we need it?](https://www.qir-alliance.org/qir-book/concepts/why-do-we-need.html). This project was conceived in collaboration with [QOSF](https://qosf.org/) (Quantum Open Source Foundation).

--- a/src/projects/qBraid-SDK.md
+++ b/src/projects/qBraid-SDK.md
@@ -12,7 +12,16 @@ tags:
   - Provider
   - Runtime
 bounties:
-  - TBD
+  - issue_num: 626
+    value: 150
+  - issue_num: 618
+    value: 75
+  - issue_num: 619
+    value: 125
+  - issue_num: 624
+    value: 75
+  - issue_num: 625
+    value: 75
 ---
 
 The [qBraid-SDK](https://github.com/qBraid/qBraid) is a platform-agnostic quantum runtime framework designed for both quantum software and hardware providers.

--- a/src/projects/quantumtoolbox.md
+++ b/src/projects/quantumtoolbox.md
@@ -10,7 +10,14 @@ tags:
   - optics
   - julia
 bounties:
-  - TBD
+  - issue_num: 81
+    value: 125
+  - issue_num: 82
+    value: 125
+  - issue_num: 84
+    value: 125
+  - issue_num: 95
+    value: 125
 ---
 
 # QuantumToolbox

--- a/src/projects/rustworkx.md
+++ b/src/projects/rustworkx.md
@@ -10,7 +10,14 @@ tags:
   - rust
   - graph theory
 bounties:
-  - TBD
+  - issue_num: 318
+    value: 75
+  - issue_num: 319
+    value: 75
+  - issue_num: 320
+    value: 100
+  - issue_num: 321
+    value: 200
 ---
 
 A high-performance, general-purpose graph library for Python, written in Rust. You can see the full rendered docs at: https://www.rustworkx.org/

--- a/src/projects/scqubits.md
+++ b/src/projects/scqubits.md
@@ -8,6 +8,17 @@ summary: scqubits is an open-source Python library for simulating superconductin
 tags:
   - superconducting circuits
   - simulation
+bounties:
+  - issue_num: 218
+    value: 150
+  - issue_num: 219
+    value: 75
+  - issue_num: 220
+    value: 100
+  - issue_num: 221
+    value: 125
+  - issue_num: 222
+    value: 50
 ---
 
 scqubits is an open-source Python library for simulating superconducting qubits. It is meant to give the user a convenient way to obtain energy spectra of common superconducting qubits, plot energy levels as a function of external parameters, calculate matrix elements etc. The library further provides an interface to QuTiP, making it easy to work with composite Hilbert spaces consisting of coupled superconducting qubits and harmonic modes. Internally, numerics within scqubits is carried out with the help of Numpy and Scipy; plotting capabilities rely on Matplotlib.

--- a/src/projects/toqito.md
+++ b/src/projects/toqito.md
@@ -12,7 +12,18 @@ tags:
   - semidefinite-programming
   - quantum-information-theory
 bounties:
-  - TBD
+  - issue_num: 519
+    value: 80
+  - issue_num: 554
+    value: 100
+  - issue_num: 518
+    value: 80
+  - issue_num: 168
+    value: 80
+  - issue_num: 431
+    value: 80
+  - issue_num: 401
+    value: 80
 ---
 
 (Theory of Quantum Information Toolkit)


### PR DESCRIPTION
This is everything in our AirTable, except for the following:

```
title: Perceval,
bounties:
  - issue_num: 399
    value: 200
  - issue_num: 400
    value: 200
  - issue_num: 207
    value: 100
title: pyQuil,
bounties:
  - issue_num: 410
    value: 80
  - issue_num: 411
    value: 80
  - issue_num: 412
    value: 80
  - issue_num: 413
    value: 80
  - issue_num: 414
    value: 80
title: pennylane-lightning,
bounties:
  - issue_num: 113
    value: 80
  - issue_num: 114
    value: 80
  - issue_num: 115
    value: 80
  - issue_num: 116
    value: 80
  - issue_num: 117
    value: 80
title: Catalyst Quantum,
bounties:
  - issue_num: 260
    value: 100
  - issue_num: 261
    value: 100
  - issue_num: 262
    value: 100
  - issue_num: 263
    value: 100
  - issue_num: 264
    value: 100
```

...which don't correspond with a specific project page. (Two of them are PennyLane, but it looks like they should be treated as independent projects.)